### PR TITLE
Add admin UI for manual check query management

### DIFF
--- a/cmd/cli/cmd/setup.go
+++ b/cmd/cli/cmd/setup.go
@@ -75,37 +75,37 @@ func setupCheckQueries() {
 	queries := []struct {
 		name        string
 		description string
-		template    string
 	}{
 		{
 			name:        "Dockerfile Analysis",
 			description: "Dockerfileの内容を分析し、ベストプラクティスの遵守状況を評価します。",
-			template:    "このリポジトリのDockerfileを分析してください。セキュリティ上の問題、ベストプラクティスの遵守状況、改善提案があれば教えてください。",
 		},
 		{
 			name:        "README Quality Assessment",
 			description: "READMEファイルの品質と完成度を評価します。",
-			template:    "このリポジトリのREADMEファイルを評価してください。プロジェクトの説明、インストール方法、使用方法の記載状況を分析し、改善点があれば提案してください。",
 		},
 		{
 			name:        "Technology Stack Analysis",
 			description: "使用されている技術スタックと依存関係を分析します。",
-			template:    "このリポジトリで使用されている技術スタック（プログラミング言語、フレームワーク、ライブラリ）を特定し、現代的な技術の使用状況を評価してください。",
 		},
 		{
 			name:        "Project Structure Assessment",
 			description: "プロジェクトの構造とディレクトリ組織を評価します。",
-			template:    "このリポジトリのプロジェクト構造を分析してください。ディレクトリの組織化、ファイルの配置、全体的な構造の適切性を評価し、改善提案があれば教えてください。",
 		},
 		{
 			name:        "Security Analysis",
 			description: "セキュリティ上の懸念事項や脆弱性を分析します。",
-			template:    "このリポジトリをセキュリティの観点から分析してください。潜在的な脆弱性、機密情報の漏洩リスク、セキュリティベストプラクティスの遵守状況を評価してください。",
 		},
 	}
 
 	for _, query := range queries {
-		if err := db.InsertCheckQuery(query.name, query.description, query.template); err != nil {
+		desc := strings.TrimSpace(query.description)
+		var descPtr *string
+		if desc != "" {
+			descPtr = &desc
+		}
+
+		if _, err := db.InsertCheckQuery(query.name, descPtr); err != nil {
 			log.Printf("Failed to insert query '%s': %v", query.name, err)
 		} else {
 			log.Printf("✓ Inserted check query: %s", query.name)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/naoya0117/shuron2025/api/graph"
 	"github.com/naoya0117/shuron2025/api/internal/database"
+	adminserver "github.com/naoya0117/shuron2025/api/internal/server"
 
 	"github.com/99designs/gqlgen/graphql/handler"
 	"github.com/99designs/gqlgen/graphql/handler/extension"
@@ -37,6 +38,11 @@ func main() {
 
 	srv := handler.New(graph.NewExecutableSchema(graph.Config{Resolvers: &graph.Resolver{DB: db}}))
 
+	adminSrv, err := adminserver.NewAdminServer(db)
+	if err != nil {
+		log.Fatalf("Failed to initialize admin server: %v", err)
+	}
+
 	srv.AddTransport(transport.Options{})
 	srv.AddTransport(transport.GET{})
 	srv.AddTransport(transport.POST{})
@@ -48,6 +54,8 @@ func main() {
 		Cache: lru.New[string](100),
 	})
 
+	http.HandleFunc("/admin/check-queries", adminSrv.HandleCheckQueries)
+	http.HandleFunc("/admin/check-results", adminSrv.HandleCheckResults)
 	http.Handle("/", playground.Handler("GraphQL playground", "/query"))
 	http.Handle("/query", srv)
 

--- a/internal/database/batch_models.go
+++ b/internal/database/batch_models.go
@@ -7,11 +7,21 @@ import (
 )
 
 type CheckQuery struct {
-	ID            int       `json:"id"`
-	Name          string    `json:"name"`
-	Description   *string   `json:"description"`
-	QueryTemplate string    `json:"queryTemplate"`
-	CreatedAt     time.Time `json:"createdAt"`
+	ID          int       `json:"id"`
+	Name        string    `json:"name"`
+	Description *string   `json:"description"`
+	CreatedAt   time.Time `json:"createdAt"`
+}
+
+type MyCheckSummary struct {
+	RepositoryID   int       `json:"repositoryId"`
+	RepositoryName string    `json:"repositoryName"`
+	CheckQueryID   int       `json:"checkQueryId"`
+	CheckQueryName string    `json:"checkQueryName"`
+	Result         string    `json:"result"`
+	Memo           *string   `json:"memo"`
+	UpdatedAt      time.Time `json:"updatedAt"`
+	IsWebApp       *bool     `json:"isWebApp"`
 }
 
 type FailedItem struct {
@@ -33,14 +43,13 @@ var CoreTableNames = []string{
 
 func (db *DB) CreateCheckQueriesTable() error {
 	query := `
-		CREATE TABLE IF NOT EXISTS check_queries (
-			id SERIAL PRIMARY KEY,
-			name VARCHAR(255) NOT NULL,
-			description TEXT,
-			query_template TEXT NOT NULL,
-			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-		)
-	`
+                CREATE TABLE IF NOT EXISTS check_queries (
+                        id SERIAL PRIMARY KEY,
+                        name VARCHAR(255) NOT NULL,
+                        description TEXT,
+                        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )
+        `
 	_, err := db.Exec(query)
 	return err
 }
@@ -77,10 +86,10 @@ func (db *DB) CreateRepositoryWebAppChecksTable() error {
 
 func (db *DB) GetCheckQueries() ([]CheckQuery, error) {
 	query := `
-		SELECT id, name, description, query_template, created_at
-		FROM check_queries
-		ORDER BY id
-	`
+                SELECT id, name, description, created_at
+                FROM check_queries
+                ORDER BY id
+        `
 	rows, err := db.Query(query)
 	if err != nil {
 		return nil, err
@@ -96,7 +105,6 @@ func (db *DB) GetCheckQueries() ([]CheckQuery, error) {
 			&q.ID,
 			&q.Name,
 			&description,
-			&q.QueryTemplate,
 			&q.CreatedAt,
 		)
 		if err != nil {
@@ -113,13 +121,122 @@ func (db *DB) GetCheckQueries() ([]CheckQuery, error) {
 	return queries, rows.Err()
 }
 
-func (db *DB) InsertCheckQuery(name, description, queryTemplate string) error {
+func (db *DB) InsertCheckQuery(name string, description *string) (int, error) {
 	query := `
-		INSERT INTO check_queries (name, description, query_template)
-		VALUES ($1, $2, $3)
-	`
-	_, err := db.Exec(query, name, description, queryTemplate)
+                INSERT INTO check_queries (name, description)
+                VALUES ($1, $2)
+                RETURNING id
+        `
+	var id int
+	if err := db.QueryRow(query, name, description).Scan(&id); err != nil {
+		return 0, err
+	}
+	return id, nil
+}
+
+func (db *DB) GetCheckQuery(id int) (*CheckQuery, error) {
+	query := `
+                SELECT id, name, description, created_at
+                FROM check_queries
+                WHERE id = $1
+        `
+	row := db.QueryRow(query, id)
+
+	var q CheckQuery
+	var description sql.NullString
+	if err := row.Scan(&q.ID, &q.Name, &description, &q.CreatedAt); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	if description.Valid {
+		q.Description = &description.String
+	}
+
+	return &q, nil
+}
+
+func (db *DB) UpsertMyCheckedRepository(repositoryID, checkQueryID int, result string, memo *string) error {
+	query := `
+                INSERT INTO my_checked_repositories (repository_id, check_query_id, result, memo)
+                VALUES ($1, $2, $3, $4)
+                ON CONFLICT (repository_id, check_query_id) DO UPDATE SET
+                        result = EXCLUDED.result,
+                        memo = EXCLUDED.memo,
+                        updated_at = CURRENT_TIMESTAMP
+        `
+	_, err := db.Exec(query, repositoryID, checkQueryID, result, memo)
 	return err
+}
+
+func (db *DB) UpsertRepositoryWebAppCheck(repositoryID int, isWebApp bool) error {
+	query := `
+                INSERT INTO repository_webapp_checks (id, is_web_app)
+                VALUES ($1, $2)
+                ON CONFLICT (id) DO UPDATE SET
+                        is_web_app = EXCLUDED.is_web_app,
+                        updated_at = CURRENT_TIMESTAMP
+        `
+	_, err := db.Exec(query, repositoryID, isWebApp)
+	return err
+}
+
+func (db *DB) ListMyCheckSummaries(limit int) ([]MyCheckSummary, error) {
+	query := `
+                SELECT
+                        m.repository_id,
+                        r.name_with_owner,
+                        m.check_query_id,
+                        q.name,
+                        m.result,
+                        m.memo,
+                        m.updated_at,
+                        w.is_web_app
+                FROM my_checked_repositories m
+                JOIN repositories r ON r.id = m.repository_id
+                JOIN check_queries q ON q.id = m.check_query_id
+                LEFT JOIN repository_webapp_checks w ON w.id = m.repository_id
+                ORDER BY m.updated_at DESC
+                LIMIT $1
+        `
+	rows, err := db.Query(query, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var summaries []MyCheckSummary
+	for rows.Next() {
+		var summary MyCheckSummary
+		var memo sql.NullString
+		var isWebApp sql.NullBool
+
+		if err := rows.Scan(
+			&summary.RepositoryID,
+			&summary.RepositoryName,
+			&summary.CheckQueryID,
+			&summary.CheckQueryName,
+			&summary.Result,
+			&memo,
+			&summary.UpdatedAt,
+			&isWebApp,
+		); err != nil {
+			return nil, err
+		}
+
+		if memo.Valid {
+			summary.Memo = &memo.String
+		}
+		if isWebApp.Valid {
+			summary.IsWebApp = &isWebApp.Bool
+		}
+
+		summaries = append(summaries, summary)
+	}
+
+	return summaries, rows.Err()
 }
 
 func (db *DB) GetRepository(id int) (*Repository, error) {

--- a/internal/server/admin.go
+++ b/internal/server/admin.go
@@ -1,0 +1,209 @@
+package server
+
+import (
+	"embed"
+	"fmt"
+	"html/template"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/naoya0117/shuron2025/api/internal/database"
+)
+
+//go:embed templates/*.gohtml
+var templateFS embed.FS
+
+type AdminServer struct {
+	db         *database.DB
+	templates  *template.Template
+	resultOpts []string
+}
+
+type adminPageData struct {
+	CheckQueries  []database.CheckQuery
+	Repositories  []database.Repository
+	MyChecks      []database.MyCheckSummary
+	FlashMessage  string
+	ErrorMessage  string
+	ResultOptions []string
+}
+
+func NewAdminServer(db *database.DB) (*AdminServer, error) {
+	tmpl, err := template.New("admin").Funcs(template.FuncMap{
+		"boolLabel": func(v *bool) string {
+			if v == nil {
+				return "-"
+			}
+			if *v {
+				return "True"
+			}
+			return "False"
+		},
+	}).ParseFS(templateFS, "templates/admin.gohtml")
+	if err != nil {
+		return nil, fmt.Errorf("parse templates: %w", err)
+	}
+
+	return &AdminServer{
+		db:         db,
+		templates:  tmpl,
+		resultOpts: []string{"○", "×", "△"},
+	}, nil
+}
+
+func (s *AdminServer) HandleCheckQueries(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		s.renderAdminPage(w, r, "", "")
+	case http.MethodPost:
+		s.handleCreateCheckQuery(w, r)
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}
+}
+
+func (s *AdminServer) HandleCheckResults(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	s.handleCreateCheckResult(w, r)
+}
+
+func (s *AdminServer) handleCreateCheckQuery(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		s.renderAdminPage(w, r, "", "フォームの解析に失敗しました")
+		return
+	}
+
+	name := strings.TrimSpace(r.FormValue("name"))
+	description := strings.TrimSpace(r.FormValue("description"))
+
+	if name == "" {
+		s.renderAdminPage(w, r, "", "名前は必須です")
+		return
+	}
+
+	var descPtr *string
+	if description != "" {
+		descPtr = &description
+	}
+
+	if _, err := s.db.InsertCheckQuery(name, descPtr); err != nil {
+		s.renderAdminPage(w, r, "", fmt.Sprintf("チェッククエリの登録に失敗しました: %v", err))
+		return
+	}
+
+	http.Redirect(w, r, withFlash("/admin/check-queries", "チェッククエリを登録しました"), http.StatusSeeOther)
+}
+
+func (s *AdminServer) handleCreateCheckResult(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		s.renderAdminPage(w, r, "", "フォームの解析に失敗しました")
+		return
+	}
+
+	repositoryID, err := strconv.Atoi(strings.TrimSpace(r.FormValue("repository_id")))
+	if err != nil || repositoryID <= 0 {
+		s.renderAdminPage(w, r, "", "リポジトリIDが不正です")
+		return
+	}
+
+	checkQueryID, err := strconv.Atoi(strings.TrimSpace(r.FormValue("check_query_id")))
+	if err != nil || checkQueryID <= 0 {
+		s.renderAdminPage(w, r, "", "チェッククエリIDが不正です")
+		return
+	}
+
+	result := strings.TrimSpace(r.FormValue("result"))
+	if !s.isValidResult(result) {
+		s.renderAdminPage(w, r, "", "結果は○, ×, △のいずれかを選択してください")
+		return
+	}
+
+	memo := strings.TrimSpace(r.FormValue("memo"))
+	var memoPtr *string
+	if memo != "" {
+		memoPtr = &memo
+	}
+
+	isWebAppStr := strings.TrimSpace(r.FormValue("is_web_app"))
+	var isWebApp bool
+	switch isWebAppStr {
+	case "true":
+		isWebApp = true
+	case "false":
+		isWebApp = false
+	default:
+		s.renderAdminPage(w, r, "", "Webアプリ判定はTrueかFalseを指定してください")
+		return
+	}
+
+	if err := s.db.UpsertMyCheckedRepository(repositoryID, checkQueryID, result, memoPtr); err != nil {
+		s.renderAdminPage(w, r, "", fmt.Sprintf("判定結果の保存に失敗しました: %v", err))
+		return
+	}
+
+	if err := s.db.UpsertRepositoryWebAppCheck(repositoryID, isWebApp); err != nil {
+		s.renderAdminPage(w, r, "", fmt.Sprintf("Webアプリ判定の保存に失敗しました: %v", err))
+		return
+	}
+
+	http.Redirect(w, r, withFlash("/admin/check-queries", "判定結果を登録しました"), http.StatusSeeOther)
+}
+
+func (s *AdminServer) renderAdminPage(w http.ResponseWriter, r *http.Request, flash, errMsg string) {
+	queries, err := s.db.GetCheckQueries()
+	if err != nil {
+		http.Error(w, fmt.Sprintf("チェッククエリの取得に失敗しました: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	repos, err := s.db.GetRepositories(50, 0)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("リポジトリ一覧の取得に失敗しました: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	checks, err := s.db.ListMyCheckSummaries(50)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("判定履歴の取得に失敗しました: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	if flash == "" {
+		flash = r.URL.Query().Get("flash")
+	}
+	if errMsg == "" {
+		errMsg = r.URL.Query().Get("error")
+	}
+
+	data := adminPageData{
+		CheckQueries:  queries,
+		Repositories:  repos,
+		MyChecks:      checks,
+		FlashMessage:  flash,
+		ErrorMessage:  errMsg,
+		ResultOptions: s.resultOpts,
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := s.templates.ExecuteTemplate(w, "admin.gohtml", data); err != nil {
+		http.Error(w, fmt.Sprintf("テンプレートの描画に失敗しました: %v", err), http.StatusInternalServerError)
+	}
+}
+
+func (s *AdminServer) isValidResult(result string) bool {
+	for _, opt := range s.resultOpts {
+		if opt == result {
+			return true
+		}
+	}
+	return false
+}
+
+func withFlash(path, message string) string {
+	return fmt.Sprintf("%s?flash=%s", path, url.QueryEscape(message))
+}

--- a/internal/server/templates/admin.gohtml
+++ b/internal/server/templates/admin.gohtml
@@ -1,0 +1,271 @@
+{{define "admin.gohtml"}}
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="utf-8">
+    <title>チェッククエリ管理</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            margin: 0;
+            padding: 0;
+            background: #f5f6f8;
+            color: #222;
+        }
+        header {
+            background: #1f2937;
+            color: #fff;
+            padding: 16px 24px;
+        }
+        main {
+            padding: 24px;
+        }
+        h1 {
+            margin: 0;
+            font-size: 24px;
+        }
+        h2 {
+            margin-top: 32px;
+            font-size: 20px;
+            border-bottom: 2px solid #e5e7eb;
+            padding-bottom: 8px;
+        }
+        form {
+            background: #fff;
+            padding: 16px;
+            border-radius: 8px;
+            box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+            margin-bottom: 24px;
+        }
+        label {
+            display: block;
+            font-weight: 600;
+            margin-bottom: 4px;
+        }
+        input[type="text"],
+        input[type="number"],
+        textarea,
+        select {
+            width: 100%;
+            padding: 8px;
+            border: 1px solid #d1d5db;
+            border-radius: 4px;
+            margin-bottom: 12px;
+        }
+        textarea {
+            min-height: 80px;
+        }
+        button {
+            background: #2563eb;
+            color: #fff;
+            border: none;
+            padding: 10px 16px;
+            border-radius: 4px;
+            cursor: pointer;
+        }
+        button:hover {
+            background: #1d4ed8;
+        }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            background: #fff;
+            margin-bottom: 24px;
+            box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+        }
+        th, td {
+            padding: 10px 12px;
+            border-bottom: 1px solid #e5e7eb;
+            text-align: left;
+        }
+        th {
+            background: #f3f4f6;
+            font-weight: 600;
+        }
+        .flash {
+            background: #d1fae5;
+            color: #065f46;
+            border: 1px solid #34d399;
+            padding: 12px 16px;
+            border-radius: 6px;
+            margin-bottom: 24px;
+        }
+        .error {
+            background: #fee2e2;
+            color: #b91c1c;
+            border: 1px solid #fca5a5;
+            padding: 12px 16px;
+            border-radius: 6px;
+            margin-bottom: 24px;
+        }
+        .memo {
+            white-space: pre-wrap;
+        }
+        .table-container {
+            overflow-x: auto;
+        }
+    </style>
+</head>
+<body>
+<header>
+    <h1>チェッククエリ管理</h1>
+</header>
+<main>
+    {{if .FlashMessage}}
+    <div class="flash">{{.FlashMessage}}</div>
+    {{end}}
+    {{if .ErrorMessage}}
+    <div class="error">{{.ErrorMessage}}</div>
+    {{end}}
+
+    <section>
+        <h2>チェッククエリの登録</h2>
+        <form method="post" action="/admin/check-queries">
+            <label for="name">名前 *</label>
+            <input type="text" id="name" name="name" required>
+
+            <label for="description">説明</label>
+            <textarea id="description" name="description" placeholder="チェック内容の概要"></textarea>
+
+            <button type="submit">登録する</button>
+        </form>
+    </section>
+
+    <section>
+        <h2>登録済みチェッククエリ</h2>
+        <div class="table-container">
+            <table>
+                <thead>
+                    <tr>
+                        <th>ID</th>
+                        <th>名前</th>
+                        <th>説明</th>
+                        <th>作成日時</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {{if .CheckQueries}}
+                        {{range .CheckQueries}}
+                        <tr>
+                            <td>{{.ID}}</td>
+                            <td>{{.Name}}</td>
+                            <td>{{if .Description}}{{.Description}}{{else}}-{{end}}</td>
+                            <td>{{.CreatedAt.Format "2006-01-02 15:04"}}</td>
+                        </tr>
+                        {{end}}
+                    {{else}}
+                        <tr>
+                            <td colspan="4">登録されたチェッククエリはありません。</td>
+                        </tr>
+                    {{end}}
+                </tbody>
+            </table>
+        </div>
+    </section>
+
+    <section>
+        <h2>手動チェック結果の登録</h2>
+        <form method="post" action="/admin/check-results">
+            <label for="repository_id">リポジトリID *</label>
+            <input type="number" id="repository_id" name="repository_id" required min="1">
+
+            <label for="check_query_id">チェッククエリID *</label>
+            <input type="number" id="check_query_id" name="check_query_id" required min="1">
+
+            <label for="result">結果 *</label>
+            <select id="result" name="result" required>
+                <option value="" disabled selected>選択してください</option>
+                {{range .ResultOptions}}
+                <option value="{{.}}">{{.}}</option>
+                {{end}}
+            </select>
+
+            <label for="memo">メモ</label>
+            <textarea id="memo" name="memo" placeholder="補足情報があれば記入"></textarea>
+
+            <label for="is_web_app">Webアプリ判定 *</label>
+            <select id="is_web_app" name="is_web_app" required>
+                <option value="" disabled selected>選択してください</option>
+                <option value="true">True</option>
+                <option value="false">False</option>
+            </select>
+
+            <button type="submit">結果を保存する</button>
+        </form>
+    </section>
+
+    <section>
+        <h2>最近の判定結果 (最新50件)</h2>
+        <div class="table-container">
+            <table>
+                <thead>
+                    <tr>
+                        <th>リポジトリID</th>
+                        <th>リポジトリ</th>
+                        <th>チェッククエリ</th>
+                        <th>結果</th>
+                        <th>Webアプリ</th>
+                        <th>メモ</th>
+                        <th>更新日時</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {{if .MyChecks}}
+                        {{range .MyChecks}}
+                        <tr>
+                            <td>{{.RepositoryID}}</td>
+                            <td>{{.RepositoryName}}</td>
+                            <td>{{.CheckQueryName}} (ID: {{.CheckQueryID}})</td>
+                            <td>{{.Result}}</td>
+                            <td>{{boolLabel .IsWebApp}}</td>
+                            <td class="memo">{{if .Memo}}{{.Memo}}{{else}}-{{end}}</td>
+                            <td>{{.UpdatedAt.Format "2006-01-02 15:04"}}</td>
+                        </tr>
+                        {{end}}
+                    {{else}}
+                        <tr>
+                            <td colspan="7">判定結果はまだ登録されていません。</td>
+                        </tr>
+                    {{end}}
+                </tbody>
+            </table>
+        </div>
+    </section>
+
+    <section>
+        <h2>リポジトリ一覧 (上位50件)</h2>
+        <div class="table-container">
+            <table>
+                <thead>
+                    <tr>
+                        <th>ID</th>
+                        <th>Name With Owner</th>
+                        <th>スター数</th>
+                        <th>主要言語</th>
+                        <th>Dockerfile</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {{if .Repositories}}
+                        {{range .Repositories}}
+                        <tr>
+                            <td>{{.ID}}</td>
+                            <td>{{.NameWithOwner}}</td>
+                            <td>{{.StargazerCount}}</td>
+                            <td>{{if .PrimaryLanguage}}{{.PrimaryLanguage}}{{else}}-{{end}}</td>
+                            <td>{{if .HasDockerfile}}Yes{{else}}No{{end}}</td>
+                        </tr>
+                        {{end}}
+                    {{else}}
+                        <tr>
+                            <td colspan="5">登録済みのリポジトリはありません。</td>
+                        </tr>
+                    {{end}}
+                </tbody>
+            </table>
+        </div>
+    </section>
+</main>
+</body>
+</html>
+{{end}}


### PR DESCRIPTION
## Summary
- add an embedded admin HTTP handler and template that lets users register check queries and record manual check results together with web app flags
- extend the database layer with helpers for inserting check queries, upserting manual check results, and listing recent review history for the UI
- expose the admin routes from the server entrypoint and update the CLI seeding logic to work with the new insertion helper signature

## Testing
- go test ./... *(fails: command hung in the offline environment; interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68fbb2975950832893006763b0fd02fb